### PR TITLE
Adding support for namespacing in credentials.properties.

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -7,7 +7,7 @@ class activemq::service inherits activemq {
   # ActiveMQ 5.9 drops the need for this, 
   # version could be obtained from fact...
   $subscription = $amqrestart ? {
-     true  => File[$configfile],
+     true  => File[$configfile,$credentials],
      false => undef
   }
 

--- a/templates/credentials.properties.erb
+++ b/templates/credentials.properties.erb
@@ -1,5 +1,5 @@
 # file managed by puppet.
 <% @data['users'].each do |u| -%>
-<%= u['username'] %>.username=<%= u['username'] %> 
-<%= u['username'] %>.password=<%= u['password'] %>
+<%= u['namespace'] %>.username=<%= u['username'] %> 
+<%= u['namespace'] %>.password=<%= u['password'] %>
 <% end -%>


### PR DESCRIPTION
Out-of-the-box configuration with this module supports the jetty webconsole, but webconsole fails to find ${activemq.username} and ${activemq.password} in credentials.properties. Default configuration specifies activemq.username in this file. Current activemq::user type uses the username specified to create entries like system.user=system, which don't allow this user to be added. Adding $namespace parameter to allow creating of entries of like activemq.username=system. $namespace defaults to $username, unless explicitly set, so should be backwards compatible.
